### PR TITLE
Optimize container image builds with pre-built binaries

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,6 +19,8 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     git curl wget jq openssh-clients ca-certificates tar gzip unzip which \
     # Modern replacements for grep/find/cat
     ripgrep fd-find bat fzf \
+    # Git diff and smart cd (from Fedora repos)
+    git-delta zoxide \
     # Editor
     neovim \
     # Shell
@@ -27,8 +29,6 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     procps-ng httpie \
     # Build essentials for native modules
     gcc gcc-c++ make pkgconf \
-    # Required for git-delta (oniguruma regex)
-    oniguruma-devel \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
@@ -46,17 +46,13 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/cache/dnf \
     && node --version && npm --version
 
-# Rust-based tools: delta (git diff), zoxide (smart cd), mcfly (shell history)
-# Install via cargo, then remove rustup to save space
-# RUSTONIG_SYSTEM_LIBONIG tells onig_sys to use system oniguruma instead of bundled
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
-    && . "$HOME/.cargo/env" \
-    && RUSTONIG_SYSTEM_LIBONIG=1 cargo install git-delta zoxide mcfly --locked \
-    && mv ~/.cargo/bin/delta /usr/local/bin/ \
-    && mv ~/.cargo/bin/zoxide /usr/local/bin/ \
-    && mv ~/.cargo/bin/mcfly /usr/local/bin/ \
-    && rustup self uninstall -y \
-    && rm -rf ~/.cargo ~/.rustup
+# mcfly (shell history search) - download pre-built binary
+# git-delta and zoxide are installed via dnf above
+ARG MCFLY_VERSION=v0.9.2
+RUN ARCH=$(uname -m) && \
+    curl -fsSL "https://github.com/cantino/mcfly/releases/download/${MCFLY_VERSION}/mcfly-${MCFLY_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" | \
+    tar -xz -C /usr/local/bin mcfly && \
+    chmod +x /usr/local/bin/mcfly
 
 # Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code \

--- a/images/rust/Dockerfile
+++ b/images/rust/Dockerfile
@@ -11,9 +11,6 @@ LABEL org.opencontainers.image.description="Minotaur Rust development image"
 
 USER root
 
-# Install OpenSSL dev headers (needed by cargo-outdated)
-RUN dnf install -y --setopt=install_weak_deps=False openssl-devel && dnf clean all
-
 # Install rustup and toolchain in shared location
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
@@ -22,10 +19,12 @@ ENV PATH="${CARGO_HOME}/bin:${PATH}"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain stable --profile minimal \
     && rustup component add rustfmt clippy \
+    # Install cargo-binstall for fast binary downloads
+    && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
     # bacon: TUI file watcher (replaces archived cargo-watch)
     # cargo-edit: add/rm/upgrade commands
     # cargo-outdated: check for outdated dependencies
-    && cargo install bacon cargo-edit cargo-outdated --locked \
+    && cargo binstall -y bacon cargo-edit cargo-outdated \
     && chmod -R a+rX ${RUSTUP_HOME} ${CARGO_HOME} \
     && chown -R developer:developer ${CARGO_HOME} ${RUSTUP_HOME}
 


### PR DESCRIPTION
## Summary
- Replace cargo compilation with Fedora packages and pre-built binaries
- Use cargo-binstall for Rust development tools
- Reduces tool installation from ~250s to ~20s (~90% faster)

## Changes

**Base image:**
- Install git-delta and zoxide from Fedora repos (dnf)
- Download mcfly as pre-built binary from GitHub releases
- Remove rustup/cargo toolchain (no longer needed)
- Remove oniguruma-devel dependency

**Rust image:**
- Use cargo-binstall instead of cargo install
- Remove openssl-devel dependency (binaries don't need it)

## Test plan
- [x] `./images/build.sh` - all 44 tests pass
- [x] Verified delta, zoxide, mcfly work in base image
- [x] Verified bacon, cargo-add, cargo-outdated work in rust image