### PR TITLE
fix: auto-remove detached containers to prevent credential leakage

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -317,10 +317,8 @@ pub async fn execute(args: RunArgs, config: &Config) -> MinoResult<()> {
     }
 
     if args.detach {
-        // Detached mode: run -d returns container ID immediately
-        // TODO: Detached containers also need removal after stop for credential cleanup.
-        // The `mino stop` command should call runtime.remove() after stopping.
-        // See: container security hardening review issue #10.
+        // Detached mode: --rm auto-removes the container when its process exits,
+        // preventing credential persistence in `podman inspect`.
         let container_id = match runtime.run(&container_config, &command).await {
             Ok(id) => id,
             Err(e) => {
@@ -871,6 +869,7 @@ fn build_container_config(
         },
         security_opt: vec!["no-new-privileges".to_string()],
         pids_limit: 4096,
+        auto_remove: args.detach,
     })
 }
 


### PR DESCRIPTION
## Summary
- Adds `--rm` to Podman's detached `run` command so containers are automatically removed when their process exits, preventing credential leakage via `podman inspect`
- Hardens `mino stop` to tolerate already-removed containers (no error when `--rm` already cleaned up)
- Removes the TODO comment tracking this gap (was deferred issue from v1.2.0 review)

## Changes
| File | Change |
|------|--------|
| `src/orchestration/podman.rs` | `auto_remove: bool` field + `--rm` in `push_args()` + test |
| `src/cli/commands/run.rs` | `auto_remove: args.detach`, replaced TODO |
| `src/cli/commands/stop.rs` | Tolerates "no such container" in stop/kill path |

## Test plan
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy` 0 warnings
- [x] `cargo test` — 210 unit + 10 integration pass (1 new: `push_args_auto_remove`)
- [x] TODO grep confirms removal
- [ ] Manual: `mino run -d -- sleep 5` → after 5s, `podman ps -a` shows no stopped container
- [ ] Manual: `mino run -d -- sleep 60` → `mino stop <name>` succeeds cleanly