### PR TITLE
security: harden trust gate — gate workdir and vm.* fields

### DIFF
--- a/src/config/trust.rs
+++ b/src/config/trust.rs
@@ -126,6 +126,12 @@ pub fn hash_content(bytes: &[u8]) -> String {
     hex::encode(hasher.finalize())
 }
 
+/// Sections with key-level sensitivity checks.
+const SENSITIVE_SECTIONS: &[(&str, &[&str])] = &[
+    ("container", SENSITIVE_CONTAINER_KEYS),
+    ("vm", SENSITIVE_VM_KEYS),
+];
+
 /// Walk the parsed TOML value and check for sensitive key paths.
 pub fn analyze_sensitive_fields(value: &toml::Value) -> SensitiveAnalysis {
     let Some(table) = value.as_table() else {
@@ -134,18 +140,12 @@ pub fn analyze_sensitive_fields(value: &toml::Value) -> SensitiveAnalysis {
 
     let mut fields = Vec::new();
 
-    if let Some(container) = table.get("container").and_then(|v| v.as_table()) {
-        for key in SENSITIVE_CONTAINER_KEYS {
-            if container.contains_key(*key) {
-                fields.push(format!("container.{key}"));
-            }
-        }
-    }
-
-    if let Some(vm) = table.get("vm").and_then(|v| v.as_table()) {
-        for key in SENSITIVE_VM_KEYS {
-            if vm.contains_key(*key) {
-                fields.push(format!("vm.{key}"));
+    for (section, keys) in SENSITIVE_SECTIONS {
+        if let Some(sub) = table.get(*section).and_then(|v| v.as_table()) {
+            for key in *keys {
+                if sub.contains_key(*key) {
+                    fields.push(format!("{section}.{key}"));
+                }
             }
         }
     }
@@ -170,17 +170,17 @@ fn format_sensitive_summary(value: &toml::Value, fields: &[String]) -> String {
             if let Some(creds) = table.get("credentials") {
                 lines.push(format!("[credentials] = {}", summarize_value(creds)));
             }
-        } else if let Some(rest) = field.strip_prefix("container.") {
-            if let Some(container) = table.get("container").and_then(|v| v.as_table()) {
-                if let Some(val) = container.get(rest) {
-                    lines.push(format!("container.{rest} = {}", summarize_value(val)));
-                }
-            }
-        } else if let Some(rest) = field.strip_prefix("vm.") {
-            if let Some(vm) = table.get("vm").and_then(|v| v.as_table()) {
-                if let Some(val) = vm.get(rest) {
-                    lines.push(format!("vm.{rest} = {}", summarize_value(val)));
-                }
+            continue;
+        }
+
+        // Handle section.key fields (e.g. "container.network", "vm.name")
+        if let Some((section, key)) = field.split_once('.') {
+            if let Some(val) = table
+                .get(section)
+                .and_then(|v| v.as_table())
+                .and_then(|t| t.get(key))
+            {
+                lines.push(format!("{section}.{key} = {}", summarize_value(val)));
             }
         }
     }
@@ -389,6 +389,9 @@ mod tests {
             volumes = ["/etc:/etc:ro"]
             image = "evil:latest"
 
+            [vm]
+            name = "attacker-vm"
+
             [credentials.aws]
             enabled = true
             "#,
@@ -399,8 +402,9 @@ mod tests {
         assert!(analysis.fields.contains(&"container.network".to_string()));
         assert!(analysis.fields.contains(&"container.volumes".to_string()));
         assert!(analysis.fields.contains(&"container.image".to_string()));
+        assert!(analysis.fields.contains(&"vm.name".to_string()));
         assert!(analysis.fields.contains(&"credentials".to_string()));
-        assert_eq!(analysis.fields.len(), 4);
+        assert_eq!(analysis.fields.len(), 5);
     }
 
     #[test]
@@ -595,5 +599,25 @@ mod tests {
         assert!(analysis.has_sensitive());
         assert!(analysis.fields.contains(&"container.workdir".to_string()));
         assert_eq!(analysis.fields.len(), 1);
+    }
+
+    #[test]
+    fn test_format_summary_includes_vm_fields() {
+        let value: toml::Value = toml::from_str(
+            r#"
+            [container]
+            image = "evil:latest"
+
+            [vm]
+            name = "attacker"
+            distro = "alpine"
+            "#,
+        )
+        .unwrap();
+        let analysis = analyze_sensitive_fields(&value);
+        let summary = format_sensitive_summary(&value, &analysis.fields);
+        assert!(summary.contains("container.image = \"evil:latest\""));
+        assert!(summary.contains("vm.name = \"attacker\""));
+        assert!(summary.contains("vm.distro = \"alpine\""));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `container.workdir` to `SENSITIVE_CONTAINER_KEYS` — prevents malicious `.mino.toml` from mounting the project at `/` to shadow system binaries
- Adds `SENSITIVE_VM_KEYS` (`name`, `distro`) — prevents macOS config injection redirecting commands to an attacker-controlled OrbStack VM
- Extracts `SENSITIVE_SECTIONS` const for DRY iteration across gated sections
- Consolidates `format_sensitive_summary` with generic `split_once('.')` dispatch

## Test plan

- [x] 22 trust module tests pass (15 existing + 7 new)
- [x] Full suite passes (236 unit + 10 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean