### PR TITLE
security: remove default_project_dir to eliminate trust gate bypass

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -686,18 +686,12 @@ async fn validate_environment() -> MinoResult<()> {
     Ok(())
 }
 
-fn resolve_project_dir(args: &RunArgs, config: &Config) -> MinoResult<PathBuf> {
+fn resolve_project_dir(args: &RunArgs, _config: &Config) -> MinoResult<PathBuf> {
     if let Some(ref path) = args.project {
         let canonical = path
             .canonicalize()
             .map_err(|e| MinoError::io(format!("resolving project path {}", path.display()), e))?;
         return Ok(canonical);
-    }
-
-    if let Some(ref path) = config.session.default_project_dir {
-        if path.exists() {
-            return Ok(path.clone());
-        }
     }
 
     env::current_dir().map_err(|e| MinoError::io("getting current directory", e))

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4,7 +4,6 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 /// Root configuration structure
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -226,9 +225,6 @@ pub struct SessionConfig {
 
     /// Auto-cleanup stopped/failed sessions older than N hours (0 = disabled)
     pub auto_cleanup_hours: u32,
-
-    /// Default project directory to mount
-    pub default_project_dir: Option<PathBuf>,
 }
 
 impl Default for SessionConfig {
@@ -236,7 +232,6 @@ impl Default for SessionConfig {
         Self {
             shell: "/bin/bash".to_string(),
             auto_cleanup_hours: 720,
-            default_project_dir: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Removes `session.default_project_dir` from config schema
- Simplifies `resolve_project_dir()` to only use `--project` flag or `cwd`
- Eliminates trust gate bypass vulnerability where malicious `.mino.toml` could redirect project mount via symlink

## Security Issue

The `default_project_dir` field was not included in `SENSITIVE_SECTIONS`, allowing a malicious local config to specify a symlink path (e.g., `/tmp/evil -> /etc`) that would be mounted without user confirmation.

## Fix Approach

Rather than adding another field to gate, we remove the feature entirely:
- `--project /path` still works (canonicalized, user-controlled)
- Otherwise, current working directory is used

This follows the "reduce attack surface" principle and has minimal UX impact.

## Test plan

- [x] All 246 tests pass
- [x] Clippy clean
- [x] CI passes