### PR TITLE
fix(images): fix aarch64 build failures for CLI tool downloads

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -38,7 +38,7 @@ ARG FZF_VERSION=v0.57.0
 ARG DELTA_VERSION=0.18.2
 ARG ZOXIDE_VERSION=v0.9.6
 ARG GH_VERSION=2.65.0
-ARG NVIM_VERSION=v0.10.3
+ARG NVIM_VERSION=v0.11.0
 ARG YQ_VERSION=v4.44.3
 ARG TOKEI_VERSION=v12.1.2
 ARG EZA_VERSION=v0.20.22
@@ -47,25 +47,21 @@ ARG SD_VERSION=v1.0.0
 # SHA256 checksums for CLI tool downloads (per architecture)
 # Format: TOOL_SHA256_ARCH — update these when bumping tool versions
 ARG RG_SHA256_X86_64=4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e
-# TODO: populate aarch64 checksum when multi-arch builds are enabled
-ARG RG_SHA256_AARCH64=PLACEHOLDER_NEEDS_REAL_CHECKSUM
+ARG RG_SHA256_AARCH64=c827481c4ff4ea10c9dc7a4022c8de5db34a5737cb74484d62eb94a95841ab2f
 ARG FD_SHA256_X86_64=d9bfa25ec28624545c222992e1b00673b7c9ca5eb15393c40369f10b28f9c932
 ARG FD_SHA256_AARCH64=4e8e596646d047d904f2c5ca74b39dccc69978b6e1fb101094e534b0b59c1bb0
 ARG BAT_SHA256_X86_64=d39a21e3da57fe6a3e07184b3c1dc245f8dba379af569d3668b6dcdfe75e3052
-# TODO: populate aarch64 checksum when multi-arch builds are enabled
-ARG BAT_SHA256_AARCH64=PLACEHOLDER_NEEDS_REAL_CHECKSUM
+ARG BAT_SHA256_AARCH64=feccae9a0576d97609c57e32d3914c5116136eab0df74c2ab74ef397d42c5b10
 ARG FZF_SHA256_X86_64=a3c087a5f40e8bb4d9bfb26faffa094643df111a469646bef53154a54af9ff92
 ARG FZF_SHA256_AARCH64=e0b3fd1bb769997907d373b0511401801cd643ce939d26ad42e9fe2836bed625
 ARG DELTA_SHA256_X86_64=b7ea845004762358a00ef9127dd9fd723e333c7e4b9cb1da220c3909372310ee
-# TODO: populate aarch64 checksum when multi-arch builds are enabled
-ARG DELTA_SHA256_AARCH64=PLACEHOLDER_NEEDS_REAL_CHECKSUM
+ARG DELTA_SHA256_AARCH64=adf7674086daa4582f598f74ce9caa6b70c1ba8f4a57d2911499b37826b014f9
 ARG ZOXIDE_SHA256_X86_64=eaa18f8aca1f02e1a132a9eac21b630918f96fa1cc7486ab87e7053dad37b004
 ARG ZOXIDE_SHA256_AARCH64=7da16a093b2ac16d577dc53d1f74a8199fc824c963fa3aaf77a6d9f294a895d5
 ARG GH_SHA256_X86_64=762569efe785082b7d1feb06995efece1a9cecce16da8503ac6fdbcbea04085b
 ARG GH_SHA256_AARCH64=8bcec9f3ee5c7c3700359a75da774c71221064a0ba017537795aa32ac8bbb481
-ARG NVIM_SHA256_X86_64=be189915a2a0da3615576e2db06a7c714aef0ae926b4da6107e589a3cc623e5c
-# TODO: populate aarch64 checksum when multi-arch builds are enabled
-ARG NVIM_SHA256_AARCH64=PLACEHOLDER_NEEDS_REAL_CHECKSUM
+ARG NVIM_SHA256_X86_64=fe0a5bc79e64c5e4d9f844cd96157ebd3919ef1343b329e9ebc3f455924cc7d6
+ARG NVIM_SHA256_AARCH64=6959583f45042da20e0a082dc65108725629a4739ab91246c678fd084ecaf50e
 ARG YQ_SHA256_X86_64=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
 ARG YQ_SHA256_AARCH64=0e7e1524f68d91b3ff9b089872d185940ab0fa020a5a9052046ef10547023156
 ARG TOKEI_SHA256_X86_64=c8c5c4ab9e1ff47e745de70f4af3214078657399fa7a0da0b5f209d780e49978
@@ -79,13 +75,15 @@ ARG SD_SHA256_AARCH64=9e99f8e9dd70c7015b8c20e49270bdd99e9caf966a41a11982f4d785f6
 # Each tool is downloaded to a temp file, SHA256-verified, then extracted.
 RUN set -e && mkdir -p /opt/mino-tools && ARCH=$(uname -m) && \
     # --- ripgrep ---
-    curl -fsSL "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/ripgrep-${RG_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
-        -o /tmp/rg.tar.gz && \
     case "$ARCH" in \
-        x86_64)  echo "${RG_SHA256_X86_64}  /tmp/rg.tar.gz" ;; \
-        aarch64) echo "${RG_SHA256_AARCH64}  /tmp/rg.tar.gz" ;; \
-    esac | sha256sum -c - && \
-    tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/rg.tar.gz "ripgrep-${RG_VERSION}-${ARCH}-unknown-linux-musl/rg" && \
+        x86_64)  RG_TARGET="x86_64-unknown-linux-musl"; RG_SHA256="${RG_SHA256_X86_64}" ;; \
+        aarch64) RG_TARGET="aarch64-unknown-linux-gnu"; RG_SHA256="${RG_SHA256_AARCH64}" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/ripgrep-${RG_VERSION}-${RG_TARGET}.tar.gz" \
+        -o /tmp/rg.tar.gz && \
+    echo "${RG_SHA256}  /tmp/rg.tar.gz" | sha256sum -c - && \
+    tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/rg.tar.gz "ripgrep-${RG_VERSION}-${RG_TARGET}/rg" && \
     rm /tmp/rg.tar.gz && \
     # --- fd ---
     curl -fsSL "https://github.com/sharkdp/fd/releases/download/${FD_VERSION}/fd-${FD_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
@@ -97,13 +95,15 @@ RUN set -e && mkdir -p /opt/mino-tools && ARCH=$(uname -m) && \
     tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/fd.tar.gz "fd-${FD_VERSION}-${ARCH}-unknown-linux-musl/fd" && \
     rm /tmp/fd.tar.gz && \
     # --- bat ---
-    curl -fsSL "https://github.com/sharkdp/bat/releases/download/${BAT_VERSION}/bat-${BAT_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
-        -o /tmp/bat.tar.gz && \
     case "$ARCH" in \
-        x86_64)  echo "${BAT_SHA256_X86_64}  /tmp/bat.tar.gz" ;; \
-        aarch64) echo "${BAT_SHA256_AARCH64}  /tmp/bat.tar.gz" ;; \
-    esac | sha256sum -c - && \
-    tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/bat.tar.gz "bat-${BAT_VERSION}-${ARCH}-unknown-linux-musl/bat" && \
+        x86_64)  BAT_TARGET="x86_64-unknown-linux-musl"; BAT_SHA256="${BAT_SHA256_X86_64}" ;; \
+        aarch64) BAT_TARGET="aarch64-unknown-linux-gnu"; BAT_SHA256="${BAT_SHA256_AARCH64}" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/sharkdp/bat/releases/download/${BAT_VERSION}/bat-${BAT_VERSION}-${BAT_TARGET}.tar.gz" \
+        -o /tmp/bat.tar.gz && \
+    echo "${BAT_SHA256}  /tmp/bat.tar.gz" | sha256sum -c - && \
+    tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/bat.tar.gz "bat-${BAT_VERSION}-${BAT_TARGET}/bat" && \
     rm /tmp/bat.tar.gz && \
     # --- fzf ---
     case "$ARCH" in \
@@ -117,13 +117,15 @@ RUN set -e && mkdir -p /opt/mino-tools && ARCH=$(uname -m) && \
     tar -xz -C /opt/mino-tools -f /tmp/fzf.tar.gz fzf && \
     rm /tmp/fzf.tar.gz && \
     # --- delta (git diff) ---
-    curl -fsSL "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/delta-${DELTA_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
-        -o /tmp/delta.tar.gz && \
     case "$ARCH" in \
-        x86_64)  echo "${DELTA_SHA256_X86_64}  /tmp/delta.tar.gz" ;; \
-        aarch64) echo "${DELTA_SHA256_AARCH64}  /tmp/delta.tar.gz" ;; \
-    esac | sha256sum -c - && \
-    tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/delta.tar.gz "delta-${DELTA_VERSION}-${ARCH}-unknown-linux-musl/delta" && \
+        x86_64)  DELTA_TARGET="x86_64-unknown-linux-musl"; DELTA_SHA256="${DELTA_SHA256_X86_64}" ;; \
+        aarch64) DELTA_TARGET="aarch64-unknown-linux-gnu"; DELTA_SHA256="${DELTA_SHA256_AARCH64}" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/delta-${DELTA_VERSION}-${DELTA_TARGET}.tar.gz" \
+        -o /tmp/delta.tar.gz && \
+    echo "${DELTA_SHA256}  /tmp/delta.tar.gz" | sha256sum -c - && \
+    tar -xz --strip-components=1 -C /opt/mino-tools -f /tmp/delta.tar.gz "delta-${DELTA_VERSION}-${DELTA_TARGET}/delta" && \
     rm /tmp/delta.tar.gz && \
     # --- zoxide (smart cd) ---
     curl -fsSL "https://github.com/ajeetdsouza/zoxide/releases/download/${ZOXIDE_VERSION}/zoxide-${ZOXIDE_VERSION#v}-${ARCH}-unknown-linux-musl.tar.gz" \
@@ -148,7 +150,7 @@ RUN set -e && mkdir -p /opt/mino-tools && ARCH=$(uname -m) && \
     # --- neovim ---
     case "$ARCH" in \
         x86_64)  NVIM_ARCH="x86_64"; NVIM_SHA256="${NVIM_SHA256_X86_64}" ;; \
-        aarch64) NVIM_ARCH="aarch64"; NVIM_SHA256="${NVIM_SHA256_AARCH64}" ;; \
+        aarch64) NVIM_ARCH="arm64"; NVIM_SHA256="${NVIM_SHA256_AARCH64}" ;; \
         *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
     curl -fsSL "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-${NVIM_ARCH}.tar.gz" \


### PR DESCRIPTION
## Summary

Fixes the base image Dockerfile so it builds successfully on aarch64 (macOS with OrbStack). Three categories of issues were causing build failures:

- **Wrong target triples**: ripgrep, bat, and delta don't publish `aarch64-unknown-linux-musl` builds — they use `aarch64-unknown-linux-gnu`. Added architecture-specific case blocks (matching the pattern fzf/gh/yq/sd already use) to select the correct target triple per arch.
- **Placeholder checksums**: Replaced all four `PLACEHOLDER_NEEDS_REAL_CHECKSUM` values (ripgrep, bat, delta, neovim) with verified SHA256 hashes fetched from GitHub release assets.
- **Neovim v0.10.3 has no aarch64 build**: Upgraded neovim from v0.10.3 to v0.11.0, which has proper per-arch release assets (`nvim-linux-x86_64.tar.gz`, `nvim-linux-arm64.tar.gz`).

## Changes

| Tool | Fix |
|------|-----|
| ripgrep 14.1.1 | Case block for target triple (`musl` on x86_64, `gnu` on aarch64) + real checksum |
| bat v0.24.0 | Case block for target triple (`musl` on x86_64, `gnu` on aarch64) + real checksum |
| delta 0.18.2 | Case block for target triple (`musl` on x86_64, `gnu` on aarch64) + real checksum |
| neovim | Upgraded v0.10.3 → v0.11.0; maps `aarch64` → `arm64` in filename; new checksums for both arches |

## Breaking Changes

None. This is a build-time fix only — no runtime behavior changes.

## Test plan

- [x] All 497 Rust tests pass (484 unit + 13 integration)
- [x] Clippy clean
- [x] All 24 SHA256 checksums verified as 64-char hex values (no placeholders)
- [x] Verified aarch64 release assets exist on GitHub for all tools
- [x] Checksums cross-checked against GitHub release `.sha256` files (ripgrep) and computed from downloaded archives (bat, delta, neovim)
- [ ] Build base image on aarch64 (OrbStack): `cd images && ./build.sh`
- [ ] Build base image on x86_64 (CI)